### PR TITLE
Remove boto and S3 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-boto==2.38.0
 requests==2.7.0
 beautifulsoup4==4.4.0


### PR DESCRIPTION
This PR removes the superfluous support for S3 from the `send_to.py` script and therefore the boto dependency. 
